### PR TITLE
Save basic embed metadata and URLs to files

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,6 +306,42 @@ const maxNameLength = 60;
         }
 
         /**
+         * Handle saving of "Embed data"
+         * If there has been some media embedded.
+         */
+        const embedData = parsedPost.querySelector('.card-embed');
+        if (embedData) {
+            /**
+             * For now we're just going to save the HTML itself into a file,
+             * just so that it's at the very least "saved".
+             *
+             * Then save any URLs we find into a separate file called `_embed_urls.txt`,
+             * which can be fed into `youtube-dl -a _embed_urls.txt` if the user wants to.
+             *
+             * In the future we might integrate with youtube-dl or similar, or maybe save
+             * the data as JSON file for easier parsing... maybe?
+             */
+            const embedUrls = embedData.querySelectorAll('a');
+            const urls = embedUrls.map(link => link.attributes.href);
+
+            /**
+             * No need to save a file if no URLs are found.
+             * Though this is unlikely to happen.
+             */
+            if (urls.length > 0) {
+                const embedUrlsSave = await _.saveTextFile(outputPath, '_embed_urls.txt', urls.join('\n'));
+                if (embedUrlsSave !== null) {
+                    signale.success(`Saved related embed URLs (${urls.length}): ${embedUrlsSave} for post titled: ${post.title} (${postId})`);
+                }
+            }
+
+            const embedBodySave = await _.saveTextFile(outputPath, '_embed_body.html', embedData.toString());
+            if (embedBodySave !== null) {
+                signale.success(`Saved embed data as HTML: ${embedBodySave} for post titled: ${post.title} (${postId})`);
+            }
+        }
+
+        /**
          * Save inline media (images) from the post body.
          */
         const inlineImages = await _.parseInline(post.body);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yiff-dl",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,9 +10,9 @@
       "integrity": "sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg=="
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -103,9 +103,9 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
-      "integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
         "follow-redirects": "1.5.10"
       }
@@ -664,9 +664,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node-html-parser": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.1.16.tgz",
-      "integrity": "sha512-cfqTZIYDdp5cGh3NvCD5dcEDP7hfyni7WgyFacmDynLlIZaF3GVlRk8yMARhWp/PobWt1KaCV8VKdP5LKWiVbg==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.2.12.tgz",
+      "integrity": "sha512-HnmSRgHz+nhXfaii1KBNGwtGBx8ClLZ+GDQHAUNJ43YR3krfJMSMcMwFW8qwrHioPJaiaZ6xrDkcGjlffF0rnw==",
       "requires": {
         "he": "1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yiff-dl",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "description": "Downloads files from creators on Yiff",
     "main": "index.js",
     "scripts": {
@@ -17,11 +17,11 @@
     },
     "homepage": "https://github.com/M-rcus/yiff-dl#readme",
     "dependencies": {
-        "axios": "^0.19.1",
+        "axios": "^0.19.2",
         "filenamify": "^4.1.0",
         "jsdom": "^15.2.1",
         "meow": "^5.0.0",
-        "node-html-parser": "^1.1.16",
+        "node-html-parser": "^1.2.12",
         "progress": "^2.0.3",
         "signale": "^1.4.0"
     },


### PR DESCRIPTION
Embedded metadata and URLs will be saved into `_embed_body.html` and `_embed_urls.txt` specifically in the post folder.

`_embed_body.html` is just a direct HTML-string dump of the "Embed media" section of the post (if one exists).  
> The `<iframe>` that seems to show up when inspecting the post on Yiff doesn't seem to be included though, but I've decided that for now it's not a huge concern.

`_embed_urls.txt` contains the URLs that have been found in the embedded metadata. It basically looks for any `<a>` tags (links) and throws them into the file.

So far I've only been able to test with creators that use Vimeo embeds. I want to  test with creators that use other embed providers (such as YouTube) before merging.

Closes #7 